### PR TITLE
Support AnkiMobile user actions

### DIFF
--- a/src/anking_notetypes/note_types/AnKing/Back Template.html
+++ b/src/anking_notetypes/note_types/AnKing/Back Template.html
@@ -764,3 +764,15 @@ replace the arrows/dashes from the statement below with double curly brackets-->
   var mustClickW = true;
   //END CUSTOMIZATION
 </script>
+
+<!-- ANKIMOBILE USER ACTIONS -->
+<script>
+var userJs1 = undefined
+var userJs2 = undefined
+var userJs3 = undefined
+var userJs4 = undefined
+var userJs5 = undefined
+var userJs6 = undefined
+var userJs7 = undefined
+var userJs8 = undefined
+</script>

--- a/src/anking_notetypes/note_types/AnKing/Front Template.html
+++ b/src/anking_notetypes/note_types/AnKing/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version a31e833 -->
+<!-- version 367176e -->
 <div id="text">{{cloze:Text}}</div>
 
 <br>

--- a/src/anking_notetypes/note_types/AnKingDerm/Back Template.html
+++ b/src/anking_notetypes/note_types/AnKingDerm/Back Template.html
@@ -795,3 +795,15 @@ replace the arrows/dashes from the statement below with double curly brackets-->
   var mustClickW = true;
   //END CUSTOMIZATION
 </script>
+
+<!-- ANKIMOBILE USER ACTIONS -->
+<script>
+var userJs1 = undefined
+var userJs2 = undefined
+var userJs3 = undefined
+var userJs4 = undefined
+var userJs5 = undefined
+var userJs6 = undefined
+var userJs7 = undefined
+var userJs8 = undefined
+</script>

--- a/src/anking_notetypes/note_types/AnKingDerm/Front Template.html
+++ b/src/anking_notetypes/note_types/AnKingDerm/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version a31e833 -->
+<!-- version 367176e -->
 <div id="text">{{cloze:Text}}</div>
 
 

--- a/src/anking_notetypes/note_types/AnKingMCAT/Back Template.html
+++ b/src/anking_notetypes/note_types/AnKingMCAT/Back Template.html
@@ -797,3 +797,15 @@ replace the arrows/dashes from the statement below with double curly brackets-->
   var mustClickW = true;
   //END CUSTOMIZATION
 </script>
+
+<!-- ANKIMOBILE USER ACTIONS -->
+<script>
+var userJs1 = undefined
+var userJs2 = undefined
+var userJs3 = undefined
+var userJs4 = undefined
+var userJs5 = undefined
+var userJs6 = undefined
+var userJs7 = undefined
+var userJs8 = undefined
+</script>

--- a/src/anking_notetypes/note_types/AnKingMCAT/Front Template.html
+++ b/src/anking_notetypes/note_types/AnKingMCAT/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version a31e833 -->
+<!-- version 367176e -->
 <div id="text">{{cloze:Text}}</div>
 
 

--- a/src/anking_notetypes/note_types/AnKingOverhaul/Back Template.html
+++ b/src/anking_notetypes/note_types/AnKingOverhaul/Back Template.html
@@ -916,3 +916,15 @@ replace the arrows/dashes from the statement below with double curly brackets-->
   var mustClickW = true;
   //END CUSTOMIZATION
 </script>
+
+<!-- ANKIMOBILE USER ACTIONS -->
+<script>
+var userJs1 = undefined
+var userJs2 = undefined
+var userJs3 = undefined
+var userJs4 = undefined
+var userJs5 = undefined
+var userJs6 = undefined
+var userJs7 = undefined
+var userJs8 = undefined
+</script>

--- a/src/anking_notetypes/note_types/AnKingOverhaul/Front Template.html
+++ b/src/anking_notetypes/note_types/AnKingOverhaul/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version a31e833 -->
+<!-- version 367176e -->
 <div id="text">{{cloze:Text}}</div>
 
 <br>

--- a/src/anking_notetypes/note_types/Basic-AnKing/Back Template.html
+++ b/src/anking_notetypes/note_types/Basic-AnKing/Back Template.html
@@ -465,3 +465,15 @@ replace the arrows/dashes from the statement below with double curly brackets-->
   var mustClickW = true;
   //END CUSTOMIZATION
 </script>
+
+<!-- ANKIMOBILE USER ACTIONS -->
+<script>
+var userJs1 = undefined
+var userJs2 = undefined
+var userJs3 = undefined
+var userJs4 = undefined
+var userJs5 = undefined
+var userJs6 = undefined
+var userJs7 = undefined
+var userJs8 = undefined
+</script>

--- a/src/anking_notetypes/note_types/Basic-AnKing/Front Template.html
+++ b/src/anking_notetypes/note_types/Basic-AnKing/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version a31e833 -->
+<!-- version 367176e -->
 <div id="front">{{edit:Front}}</div>
 
 <br>

--- a/src/anking_notetypes/note_types/Basic-AnKingLanguage/Back Template.html
+++ b/src/anking_notetypes/note_types/Basic-AnKingLanguage/Back Template.html
@@ -476,3 +476,15 @@ replace the arrows/dashes from the statement below with double curly brackets-->
   var mustClickW = true;
   //END CUSTOMIZATION
 </script>
+
+<!-- ANKIMOBILE USER ACTIONS -->
+<script>
+var userJs1 = undefined
+var userJs2 = undefined
+var userJs3 = undefined
+var userJs4 = undefined
+var userJs5 = undefined
+var userJs6 = undefined
+var userJs7 = undefined
+var userJs8 = undefined
+</script>

--- a/src/anking_notetypes/note_types/Basic-AnKingLanguage/Front Template.html
+++ b/src/anking_notetypes/note_types/Basic-AnKingLanguage/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version a31e833 -->
+<!-- version 367176e -->
 <div id="front">{{edit:Front}}</div>
 
 <br>

--- a/src/anking_notetypes/note_types/IO-one by one/Back Template.html
+++ b/src/anking_notetypes/note_types/IO-one by one/Back Template.html
@@ -441,3 +441,15 @@ var numTagLevelsToShow = 0;
   }
 </script>
 </div>
+
+<!-- ANKIMOBILE USER ACTIONS -->
+<script>
+var userJs1 = undefined
+var userJs2 = undefined
+var userJs3 = undefined
+var userJs4 = undefined
+var userJs5 = undefined
+var userJs6 = undefined
+var userJs7 = undefined
+var userJs8 = undefined
+</script>

--- a/src/anking_notetypes/note_types/IO-one by one/Front Template.html
+++ b/src/anking_notetypes/note_types/IO-one by one/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version a31e833 -->
+<!-- version 367176e -->
 <script>
 // ############## USER CONFIGURATION START ##############
 // Auto flip to back when One by one mode.

--- a/src/anking_notetypes/note_types/Physeo-Cloze/Back Template.html
+++ b/src/anking_notetypes/note_types/Physeo-Cloze/Back Template.html
@@ -765,3 +765,15 @@ replace the arrows/dashes from the statement below with double curly brackets-->
   var mustClickW = true;
   //END CUSTOMIZATION
 </script>
+
+<!-- ANKIMOBILE USER ACTIONS -->
+<script>
+var userJs1 = undefined
+var userJs2 = undefined
+var userJs3 = undefined
+var userJs4 = undefined
+var userJs5 = undefined
+var userJs6 = undefined
+var userJs7 = undefined
+var userJs8 = undefined
+</script>

--- a/src/anking_notetypes/note_types/Physeo-Cloze/Front Template.html
+++ b/src/anking_notetypes/note_types/Physeo-Cloze/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version a31e833 -->
+<!-- version 367176e -->
 <div id="text">{{cloze:Text}}</div>
 
 <br>

--- a/src/anking_notetypes/note_types/Physeo-IO one by one/Back Template.html
+++ b/src/anking_notetypes/note_types/Physeo-IO one by one/Back Template.html
@@ -440,3 +440,15 @@ var numTagLevelsToShow = 0;
   }
 </script>
 </div>
+
+<!-- ANKIMOBILE USER ACTIONS -->
+<script>
+var userJs1 = undefined
+var userJs2 = undefined
+var userJs3 = undefined
+var userJs4 = undefined
+var userJs5 = undefined
+var userJs6 = undefined
+var userJs7 = undefined
+var userJs8 = undefined
+</script>

--- a/src/anking_notetypes/note_types/Physeo-IO one by one/Front Template.html
+++ b/src/anking_notetypes/note_types/Physeo-IO one by one/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version a31e833 -->
+<!-- version 367176e -->
 <script>
 // ############## USER CONFIGURATION START ##############
 // Auto flip to back when One by one mode.

--- a/src/anking_notetypes/notetype_setting.py
+++ b/src/anking_notetypes/notetype_setting.py
@@ -299,7 +299,7 @@ class DropdownSetting(NotetypeSetting):
             key=self.key(model["name"]),
             description=self.config["text"],
             tooltip=self.config.get("tooltip", None),
-            labels=self.config["options"],
+            labels=self.config.get("labels", self.config["options"]),
             values=self.config["options"],
         )
 

--- a/src/anking_notetypes/notetype_setting.py
+++ b/src/anking_notetypes/notetype_setting.py
@@ -33,6 +33,8 @@ class NotetypeSetting(ABC):
             return ShortcutSetting(config)
         if config["type"] == "dropdown":
             return DropdownSetting(config)
+        if config["type"] == "useraction":
+            return UserActionSetting(config)
         if config["type"] == "color":
             return ColorSetting(config)
         if config["type"] == "font_family":
@@ -313,6 +315,19 @@ class DropdownSetting(NotetypeSetting):
 
     def _set_setting_value(self, section: str, setting_value: Any) -> str:
         return self._replace_first_capture_group(section, setting_value)
+
+class UserActionSetting(DropdownSetting):
+
+    def _extract_setting_value(self, section: str) -> Any:
+        result = re.search(self.config["regex"], section).group(1)
+        if result not in self.config["options"]:
+            # Note that custom actions will also be lableled as "None"
+            return "custom"
+        return result
+
+    def _set_setting_value(self, section: str, setting_value: Any) -> str:
+        if setting_value != "custom":
+            return self._replace_first_capture_group(section, setting_value)
 
 
 class ColorSetting(NotetypeSetting):

--- a/src/anking_notetypes/notetype_setting_definitions.py
+++ b/src/anking_notetypes/notetype_setting_definitions.py
@@ -27,6 +27,40 @@ CONFIGURABLE_FIELD_NAME_RE = r"\{\{#(.+?)\}\}"
 QUOT_STR_RE = r'(?:\\.|[^"\\])'
 
 
+HINT_BUTTONS = {
+    'ln': 'Personal/Lecture Notes',
+    'mq': 'Missed Questions',
+    'tx': 'Textbook',
+    'ar': 'Additional Resources',
+    'pixorize': 'Pixorize',
+    'sketchy': 'Sketchy',
+    'sketchy2': 'Sketchy 2',
+    'sketchyextra': 'Sketchy Extra',
+    'pat': 'Pathoma',
+    'bb': 'Boards and Beyond',
+    'picomnic': 'Picomnic',
+    'physeo': 'Physeo',
+    'bootcamp': 'Bootcamp',
+    'df': 'Definitions',
+    'exp': 'Examples',
+    'alt': 'Alternative Translations',
+    'ex': 'Extra'
+}
+# TODO: maybe we should not show an error if the user has custom actions
+ANKIMOBILE_USER_ACTIONS = [
+    "undefined", "window.revealNextCloze", "window.toggleAllCloze", "window.toggleNextButton",
+    "() => (Array.from(document.getElementsByClassName('hintBtn')).forEach(e => toggleHintBtn(e.id)))", "window.showtags",
+    "() => revealNextClozeOf('word')",
+    *[f"() => toggleHintBtn('hint-{id}')" for id in HINT_BUTTONS.keys()]
+
+]
+ANKIMOBILE_USER_ACTION_LABELS = [
+    "None", "Reveal Next Cloze", "Toggle All Clozes", "Toggle Next Button",
+    "Toggle All Buttons", "Toggle Tags", "Reveal Cloze Word",
+    *[f"Reveal {name}" for name in HINT_BUTTONS.values()]
+]
+
+
 setting_configs: Dict[str, Any] = OrderedDict(
     {
         "field_order": {
@@ -505,6 +539,16 @@ you may have to change the \"Toggle next Button\" shortcut to something else tha
             "section": "Colors",
             "default": "yellow",
         },
+        **{f"user_action_{i}": {
+            "text": f"User Action {i}",
+            "type": "dropdown",
+            "file": "back",
+            "regex": f'var +userJs{i} += +([^/\\n]*)',
+            "options": ANKIMOBILE_USER_ACTIONS,
+            "labels": ANKIMOBILE_USER_ACTION_LABELS,
+            "section": "AnkiMobile User Actions",
+            "default": "undefined",
+        } for i in range(1, 9)}
     }
 )
 
@@ -696,6 +740,7 @@ general_settings = [
     "image_occlusion_border_color",
     "image_occlusion_active_rect_color",
     "image_occlusion_active_border_color",
+    *[f"user_action_{i}" for i in range(1, 9)]
 ]
 
 

--- a/src/anking_notetypes/notetype_setting_definitions.py
+++ b/src/anking_notetypes/notetype_setting_definitions.py
@@ -46,7 +46,7 @@ HINT_BUTTONS = {
     'alt': 'Alternative Translations',
     'ex': 'Extra'
 }
-# TODO: maybe we should not show an error if the user has custom actions
+
 ANKIMOBILE_USER_ACTIONS = [
     "undefined", "window.revealNextCloze", "window.toggleAllCloze", "window.toggleNextButton",
     "() => (Array.from(document.getElementsByClassName('hintBtn')).forEach(e => toggleHintBtn(e.id)))", "window.showtags",
@@ -541,7 +541,7 @@ you may have to change the \"Toggle next Button\" shortcut to something else tha
         },
         **{f"user_action_{i}": {
             "text": f"User Action {i}",
-            "type": "dropdown",
+            "type": "useraction",
             "file": "back",
             "regex": f'var +userJs{i} += +([^/\\n]*)',
             "options": ANKIMOBILE_USER_ACTIONS,


### PR DESCRIPTION
See AnKing-Memberships/AnKing-Note-Types#110 and AnKing-Memberships/AnKing-Note-Types#113


Currently the same actions are defined for all notetypes for simplicity, so it's possible to assign actions that don't do anything in a given notetype.
![image](https://user-images.githubusercontent.com/41397710/219865002-3fd081dd-2bd1-4ce1-84cb-d3ca3815c1ee.png)

## TODO

- [ ] Maybe prevent invalid actions from being assigned at all. Looks like this require more extensive code changes and it may not be worth it.
- [x] We probably shouldn't show an error if the user has custom functions assigned to the actions.