### PR TITLE
Add option under the browser's context menu to set autoopen fields

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ aqt==2.1.54
 pyqt5==5.15.9
 pyqtwebengine==5.15.2
 pyqtwebengine-qt5==5.15.2
+PyQt5-stubs==5.15.6.0
 
 pre-commit==2.20.0
 autopep8==1.5.7

--- a/src/anking_notetypes/__init__.py
+++ b/src/anking_notetypes/__init__.py
@@ -1,8 +1,10 @@
 from concurrent.futures import Future
 from pathlib import Path
-from typing import List, Sequence
+from typing import TYPE_CHECKING, List, Sequence
 
-from anki.notes import Note, NoteId
+if TYPE_CHECKING:
+    from anki.notes import Note, NoteId
+
 from anki.utils import ids2str
 from aqt import mw
 from aqt.browser import Browser
@@ -113,7 +115,7 @@ def replace_default_addon_config_action():
     mw.addonManager.setConfigAction(ADDON_DIR_NAME, open_window)
 
 
-def hint_fields_for_nids(nids: Sequence[NoteId]) -> List[str]:
+def hint_fields_for_nids(nids: Sequence["NoteId"]) -> List[str]:
     all_fields = mw.col.db.list(
         "select distinct name from fields where ntid in (select distinct mid from notes where id in %s)"
         % ids2str(nids)
@@ -125,7 +127,7 @@ def hint_fields_for_nids(nids: Sequence[NoteId]) -> List[str]:
     return hint_fields
 
 
-def note_autoopen_fields(note: Note) -> List[str]:
+def note_autoopen_fields(note: "Note") -> List[str]:
     tags = []
     prefix = "autoopen::"
     for tag in note.tags:
@@ -135,7 +137,7 @@ def note_autoopen_fields(note: Note) -> List[str]:
 
 
 def on_auto_reveal_fields_action(
-    browser: Browser, selected_nids: Sequence[NoteId]
+    browser: Browser, selected_nids: Sequence["NoteId"]
 ) -> None:
     fields = hint_fields_for_nids(selected_nids)
     if not fields:

--- a/src/anking_notetypes/__init__.py
+++ b/src/anking_notetypes/__init__.py
@@ -144,7 +144,7 @@ def on_auto_reveal_fields_action(
         tooltip("No hint fields found in the selected notes.", parent=browser)
         return
     current = (
-        note_autoopen_fields(mw.col.get_note(selected_nids[0]))
+        note_autoopen_fields(mw.col.getNote(selected_nids[0]))
         if len(selected_nids) == 1
         else []
     )
@@ -164,7 +164,7 @@ def on_auto_reveal_fields_action(
     def task() -> None:
         notes = []
         for nid in selected_nids:
-            note = mw.col.get_note(nid)
+            note = mw.col.getNote(nid)
             notes.append(note)
             new_tags = []
             for tag in note.tags:
@@ -184,7 +184,7 @@ def on_auto_reveal_fields_action(
 
 
 def on_browser_will_show_context_menu(browser: Browser, context_menu: QMenu) -> None:
-    selected_nids = browser.selected_notes()
+    selected_nids = browser.selectedNotes()
     action = context_menu.addAction(
         "AnKing Notetypes: Auto-reveal fields",
         lambda: on_auto_reveal_fields_action(browser, selected_nids),

--- a/src/anking_notetypes/__init__.py
+++ b/src/anking_notetypes/__init__.py
@@ -176,6 +176,7 @@ def on_auto_reveal_fields_action(
 
     def on_done(fut: Future) -> None:
         mw.progress.finish()
+        browser.onReset()
         fut.result()
 
     mw.progress.start(label="Updating notes...", immediate=True)

--- a/src/anking_notetypes/__init__.py
+++ b/src/anking_notetypes/__init__.py
@@ -1,27 +1,29 @@
-from typing import Sequence, List
-
 from pathlib import Path
+from typing import List, Sequence
 
-from anki.collection import OpChanges, Collection
-from aqt.operations import CollectionOp
-from anki.notes import NoteId, Note
+from anki.collection import Collection, OpChanges
+from anki.notes import Note, NoteId
 from anki.utils import ids2str
-
 from aqt import mw
-from aqt.gui_hooks import card_layout_will_show, profile_did_open, browser_will_show_context_menu
-from aqt.qt import QPushButton, QMenu
-from aqt.utils import askUserDialog, tooltip
 from aqt.browser import Browser
+from aqt.gui_hooks import (
+    browser_will_show_context_menu,
+    card_layout_will_show,
+    profile_did_open,
+)
+from aqt.operations import CollectionOp
+from aqt.qt import QMenu, QPushButton
+from aqt.utils import askUserDialog, tooltip
 
 from .compat import add_compat_aliases
 from .gui.config_window import (
     NotetypesConfigWindow,
-    note_type_version,
     models_with_available_updates,
+    note_type_version,
 )
 from .gui.menu import setup_menu
 from .gui.utils import choose_subset
-from .notetype_setting_definitions import anking_notetype_models, HINT_BUTTONS
+from .notetype_setting_definitions import HINT_BUTTONS, anking_notetype_models
 
 ADDON_DIR_NAME = str(Path(__file__).parent.name)
 RESOURCES_PATH = Path(__file__).parent / "resources"
@@ -66,7 +68,6 @@ def add_button_to_clayout(clayout):
 
 
 def maybe_show_notetypes_update_notice():
-
     # can happen when restoring data from backup
     if not mw.col:
         return
@@ -115,7 +116,9 @@ def replace_default_addon_config_action():
 
 def hint_fields_for_nids(nids: Sequence[NoteId]) -> List[str]:
     all_fields = mw.col.db.list(
-        'select distinct name from fields where ntid in (select distinct mid from notes where id in %s)' % ids2str(nids))
+        "select distinct name from fields where ntid in (select distinct mid from notes where id in %s)"
+        % ids2str(nids)
+    )
     hint_fields = []
     for field in all_fields:
         if field in HINT_BUTTONS.values():
@@ -128,16 +131,22 @@ def note_autoopen_fields(note: Note) -> List[str]:
     prefix = "autoopen::"
     for tag in note.tags:
         if tag.startswith(prefix):
-            tags.append(tag[tag.index(prefix) + len(prefix):].replace('_', ' '))
+            tags.append(tag[tag.index(prefix) + len(prefix) :].replace("_", " "))
     return tags
 
 
-def on_auto_reveal_fields_action(browser: Browser, selected_nids: Sequence[NoteId]) -> None:
+def on_auto_reveal_fields_action(
+    browser: Browser, selected_nids: Sequence[NoteId]
+) -> None:
     fields = hint_fields_for_nids(selected_nids)
     if not fields:
         tooltip("No hint fields found in the selected notes.", parent=browser)
         return
-    current = note_autoopen_fields(mw.col.get_note(selected_nids[0])) if len(selected_nids) == 1 else []
+    current = (
+        note_autoopen_fields(mw.col.get_note(selected_nids[0]))
+        if len(selected_nids) == 1
+        else []
+    )
     chosen = choose_subset(
         "Choose which fields of the selected notes should be automatically revealed<br>",
         choices=fields,

--- a/src/anking_notetypes/gui/utils.py
+++ b/src/anking_notetypes/gui/utils.py
@@ -74,8 +74,10 @@ def choose_subset(
 
     layout.addSpacing(10)
 
-    button_box = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok)
+    button_box = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel)
     qconnect(button_box.accepted, dialog.accept)
+    qconnect(button_box.rejected, dialog.reject)
+
     layout.addWidget(button_box)
 
     if adjust_height_to_content:

--- a/src/anking_notetypes/gui/utils.py
+++ b/src/anking_notetypes/gui/utils.py
@@ -1,0 +1,94 @@
+
+from typing import Any, List, Optional
+
+import aqt
+from aqt.qt import (QDialog, QDialogButtonBox, QLabel, QListWidget,
+                    QListWidgetItem, QPushButton, Qt, QVBoxLayout, qconnect)
+from aqt.utils import disable_help_button
+
+# NOTE: Adapted from AnkiHub
+
+
+def choose_subset(
+    prompt: str,
+    choices: List[str],
+    current: List[str] = [],
+    adjust_height_to_content=True,
+    description_html: Optional[str] = None,
+    parent: Any = None,
+) -> Optional[List[str]]:
+    if not parent:
+        parent = aqt.mw.app.activeWindow()
+
+    dialog = QDialog(parent)
+    disable_help_button(dialog)
+
+    dialog.setWindowModality(Qt.WindowModality.WindowModal)
+    layout = QVBoxLayout()
+    dialog.setLayout(layout)
+    label = QLabel(prompt)
+    layout.addWidget(label)
+    list_widget = QListWidget()
+    layout.addWidget(list_widget)
+
+    layout.addSpacing(5)
+
+    # add a "select all" button
+    def select_all():
+        all_selected = all(
+            list_widget.item(i).checkState() == Qt.CheckState.Checked
+            for i in range(list_widget.count())
+        )
+        if all_selected:
+            for i in range(list_widget.count()):
+                list_widget.item(i).setCheckState(Qt.CheckState.Unchecked)
+        else:
+            for i in range(list_widget.count()):
+                list_widget.item(i).setCheckState(Qt.CheckState.Checked)
+
+    button = QPushButton("Select All")
+    qconnect(button.clicked, select_all)
+    layout.addWidget(button)
+    current = [c.lower() for c in current]
+    for choice in choices:
+        item = QListWidgetItem(choice)
+        item.setFlags(item.flags() | Qt.ItemFlag.ItemIsUserCheckable)  # type: ignore
+        item.setCheckState(
+            Qt.CheckState.Checked if choice.lower() in current else Qt.CheckState.Unchecked
+        )
+        list_widget.addItem(item)
+
+    # toggle item check state when clicked
+    qconnect(
+        list_widget.itemClicked,
+        lambda item: item.setCheckState(
+            Qt.CheckState.Checked
+            if item.checkState() == Qt.CheckState.Unchecked
+            else Qt.CheckState.Unchecked
+        ),
+    )
+
+    if description_html:
+        label = QLabel(f"<i>{description_html}</i>")
+        layout.addWidget(label)
+
+    layout.addSpacing(10)
+
+    button_box = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok)
+    qconnect(button_box.accepted, dialog.accept)
+    layout.addWidget(button_box)
+
+    if adjust_height_to_content:
+        list_widget.setMinimumHeight(
+            list_widget.sizeHintForRow(0) * list_widget.count() + 20
+        )
+
+    if not dialog.exec():
+        return None
+
+    result = [
+        list_widget.item(i).text()
+        for i in range(list_widget.count())
+        if list_widget.item(i).checkState() == Qt.CheckState.Checked
+    ]
+    return result

--- a/src/anking_notetypes/gui/utils.py
+++ b/src/anking_notetypes/gui/utils.py
@@ -1,9 +1,17 @@
-
 from typing import Any, List, Optional
 
 import aqt
-from aqt.qt import (QDialog, QDialogButtonBox, QLabel, QListWidget,
-                    QListWidgetItem, QPushButton, Qt, QVBoxLayout, qconnect)
+from aqt.qt import (
+    QDialog,
+    QDialogButtonBox,
+    QLabel,
+    QListWidget,
+    QListWidgetItem,
+    QPushButton,
+    Qt,
+    QVBoxLayout,
+    qconnect,
+)
 from aqt.utils import disable_help_button
 
 # NOTE: Adapted from AnkiHub
@@ -54,7 +62,9 @@ def choose_subset(
         item = QListWidgetItem(choice)
         item.setFlags(item.flags() | Qt.ItemFlag.ItemIsUserCheckable)  # type: ignore
         item.setCheckState(
-            Qt.CheckState.Checked if choice.lower() in current else Qt.CheckState.Unchecked
+            Qt.CheckState.Checked
+            if choice.lower() in current
+            else Qt.CheckState.Unchecked
         )
         list_widget.addItem(item)
 
@@ -74,7 +84,9 @@ def choose_subset(
 
     layout.addSpacing(10)
 
-    button_box = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel)
+    button_box = QDialogButtonBox(
+        QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
+    )
     qconnect(button_box.accepted, dialog.accept)
     qconnect(button_box.rejected, dialog.reject)
 

--- a/src/anking_notetypes/gui/utils.py
+++ b/src/anking_notetypes/gui/utils.py
@@ -20,14 +20,15 @@ from aqt.utils import disable_help_button
 def choose_subset(
     prompt: str,
     choices: List[str],
-    current: List[str] = [],
+    current: Optional[List[str]] = None,
     adjust_height_to_content=True,
     description_html: Optional[str] = None,
     parent: Any = None,
 ) -> Optional[List[str]]:
     if not parent:
         parent = aqt.mw.app.activeWindow()
-
+    if current is None:
+        current = []
     dialog = QDialog(parent)
     disable_help_button(dialog)
 

--- a/src/anking_notetypes/gui/utils.py
+++ b/src/anking_notetypes/gui/utils.py
@@ -84,7 +84,6 @@ def choose_subset(
         layout.addWidget(label)
 
     layout.addSpacing(10)
-
     button_box = QDialogButtonBox(
         QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
     )

--- a/src/anking_notetypes/gui/utils.py
+++ b/src/anking_notetypes/gui/utils.py
@@ -12,7 +12,6 @@ from aqt.qt import (
     QVBoxLayout,
     qconnect,
 )
-from aqt.utils import disable_help_button
 
 # NOTE: Adapted from AnkiHub
 
@@ -30,8 +29,12 @@ def choose_subset(
     if current is None:
         current = []
     dialog = QDialog(parent)
-    disable_help_button(dialog)
+    try:
+        from aqt.utils import disable_help_button
 
+        disable_help_button(dialog)
+    except ImportError:
+        pass
     dialog.setWindowModality(Qt.WindowModality.WindowModal)
     layout = QVBoxLayout()
     dialog.setLayout(layout)


### PR DESCRIPTION
This implements @AnKingMed's suggestion in https://github.com/AnKing-Memberships/AnKing-Note-Types/pull/131#issuecomment-1556274434

![image](https://github.com/AnKing-Memberships/anking_notes_addon/assets/41397710/c703d921-d284-4302-91c5-1e24ca200d62)
![image](https://github.com/AnKing-Memberships/anking_notes_addon/assets/41397710/fd40ea39-681b-4953-8adc-703e2b0bd1a8)



This works on Anki 2.1.46+ so only the 2.1.50-2.1.61+ branch should be updated. I can port this to older versions if needed.
