### PR TITLE
Preserve custom note type CSS

### DIFF
--- a/src/anking_notetypes/constants.py
+++ b/src/anking_notetypes/constants.py
@@ -1,3 +1,6 @@
+import re
+
+
 NOTETYPE_COPY_RE = r"{notetype_base_name}-[a-zA-Z0-9]{{5}}"
 ANKIHUB_NOTETYPE_RE = r"{notetype_base_name} \(.+ / .+\)"
 
@@ -8,10 +11,24 @@ ANKIHUB_TEMPLATE_SNIPPET_RE = (
     r"[\w\W]*"
     f"<!-- END {ANKIHUB_NOTE_TYPE_MODIFICATION_STRING} -->"
 )
-ANKIHUB_TEMPLATE_END_COMMENT = (
+
+ANKIHUB_HTML_END_COMMENT = (
     "<!--\n"
     "ANKIHUB_END\n"
     "Text below this comment will not be modified by AnkiHub or AnKing add-ons.\n"
     "Do not edit or remove this comment if you want to protect the content below.\n"
     "-->"
+)
+ANKIHUB_CSS_END_COMMENT = (
+    "/*\n"
+    "ANKIHUB_END\n"
+    "Text below this comment will not be modified by AnkiHub or AnKing add-ons.\n"
+    "Do not edit or remove this comment if you want to protect the content below.\n"
+    "*/"
+)
+ANKIHUB_HTML_END_COMMENT_RE = re.compile(
+    rf"{re.escape(ANKIHUB_HTML_END_COMMENT)}(?P<text_to_migrate>[\w\W]*)"
+)
+ANKIHUB_CSS_END_COMMENT_RE = re.compile(
+    rf"{re.escape(ANKIHUB_CSS_END_COMMENT)}(?P<text_to_migrate>[\w\W]*)"
 )

--- a/src/anking_notetypes/utils.py
+++ b/src/anking_notetypes/utils.py
@@ -35,14 +35,12 @@ def update_notetype_to_newest_version(
 
     new_model = adjust_field_ords(model, new_model)
 
-    new_model = _retain_content_below_ankihub_end_comment_or_add_end_comment(
-        model, new_model
-    )
+    new_model = _retain_ankihub_modifications(model, new_model)
 
     model.update(new_model)
 
 
-def _retain_content_below_ankihub_end_comment_or_add_end_comment(
+def _retain_ankihub_modifications(
     old_model: "NotetypeDict", new_model: "NotetypeDict"
 ) -> "NotetypeDict":
     updated_templates = []
@@ -73,10 +71,11 @@ def _updated_note_type_content(
     new_content: str,
     content_type: str,
 ) -> str:
-    """Returns updated content with preserved content below ankihub end comment.
+    """Returns new_content with preserved ankihub modifications and
+    preserved content below the ankihub end comment.
 
     Args:
-      old_content: Original content to preserve custom additions from
+      old_content: Original content to preserve ankihub modifications and custom additions from
       new_content: New base content to use
       content_type: Either "html" or "css" to determine comment style
     """

--- a/src/anking_notetypes/utils.py
+++ b/src/anking_notetypes/utils.py
@@ -87,7 +87,7 @@ def _updated_note_type_content(
         end_comment_pattern = ANKIHUB_CSS_END_COMMENT_RE
 
     snippet_match = re.search(ANKIHUB_TEMPLATE_SNIPPET_RE, old_content)
-    snippet_to_migrate = snippet_match.group() if snippet_match else ""
+    ankihub_snippet = snippet_match.group() if snippet_match else ""
 
     text_to_migrate_match = re.search(end_comment_pattern, old_content)
     text_to_migrate = (
@@ -100,7 +100,7 @@ def _updated_note_type_content(
 
     return (
         result.rstrip("\n ")
-        + (f"\n{snippet_to_migrate}" if snippet_to_migrate else "")
+        + (f"\n{ankihub_snippet}" if ankihub_snippet else "")
         + "\n\n"
         + end_comment
         + "\n"


### PR DESCRIPTION
We are preserving HTML below the ankihub end comment on the note type card templates, which allows users to add modifications to them.

However, we don't have that for note type styling.

This task makes it so that content below a special ankihub end comment is preserved for the note type styling. 

It also fixes an issue where more and more white space is added to the note type templates.

Related AnkiHub add-on PR: https://github.com/AnkiHubSoftware/ankihub_addon/pull/1088

## Related issues
https://github.com/AnKing-VIP/AnKing-Note-Types/issues/219#issuecomment-2614158542

## How to reproduce
- Start Anki, go to Tools -> Note Types
- Choose an AnkiHub note type, click on Cards
- Edit the version on top of the card template
  - This will allow us to perform a note type update
- Open the AnKing Note Types dialog  (AnKing -> AnKing Note Types)
- Click the Update notetypes button and confirm
- Open the card template of the note type again, switch to the Styling tab
- Scroll to the end of the Styling content
- The AnkiHub end comment should be at the end
- Put some text above the end comment and some text below the end comment
- Edit the version on top of the card template and update note types again
- Check the Styling tab of the note type
  - The text you added above the comment shouldn't be there
  - The text you added below the comment should be still there

It's the same behavior for the other tabs besides Styling (Front Template and Back Template), which we already had previously