### PR TITLE
[NRT-34] Allow extra local fields

### DIFF
--- a/src/anking_notetypes/gui/extra_notetype_versions.py
+++ b/src/anking_notetypes/gui/extra_notetype_versions.py
@@ -72,7 +72,7 @@ def convert_extra_notetypes(
             new_model["id"] = model_copy["id"]
             new_model["name"] = model_copy["name"]  # to prevent duplicates
             new_model["usn"] = -1  # triggers full sync
-            new_model = adjust_field_ords(model_copy, new_model)
+            new_model["flds"] = adjust_field_ords(model_copy["flds"], new_model["flds"])
             mw.col.models.update_dict(new_model)
 
             # change the notes of type <notetype_copy> to type <notetype>

--- a/src/anking_notetypes/gui/extra_notetype_versions.py
+++ b/src/anking_notetypes/gui/extra_notetype_versions.py
@@ -8,7 +8,7 @@ from aqt.utils import askUser, tooltip
 
 from ..constants import NOTETYPE_COPY_RE
 from ..notetype_setting_definitions import anking_notetype_names
-from ..utils import adjust_field_ords, create_backup
+from ..utils import adjust_fields, create_backup
 
 
 def handle_extra_notetype_versions() -> None:
@@ -72,7 +72,7 @@ def convert_extra_notetypes(
             new_model["id"] = model_copy["id"]
             new_model["name"] = model_copy["name"]  # to prevent duplicates
             new_model["usn"] = -1  # triggers full sync
-            new_model["flds"] = adjust_field_ords(model_copy["flds"], new_model["flds"])
+            new_model["flds"] = adjust_fields(model_copy["flds"], new_model["flds"])
             mw.col.models.update_dict(new_model)
 
             # change the notes of type <notetype_copy> to type <notetype>

--- a/src/anking_notetypes/utils.py
+++ b/src/anking_notetypes/utils.py
@@ -147,9 +147,16 @@ def adjust_field_ords(
         for field in cur_model_fields
         if field["name"].lower() not in new_model_field_names
     ]
-    if new_model_fields[-1]["name"] == "ankihub_id":
+
+    ankihub_id_field = next(
+        (field for field in new_model_fields if field["name"] == "ankihub_id"), None
+    )
+    if ankihub_id_field:
+        new_model_fields_without_ankihub = [
+            field for field in new_model_fields if field["name"] != "ankihub_id"
+        ]
         final_fields = (
-            new_model_fields[:-1] + only_local_fields + [new_model_fields[-1]]
+            new_model_fields_without_ankihub + only_local_fields + [ankihub_id_field]
         )
     else:
         final_fields = new_model_fields + only_local_fields

--- a/src/anking_notetypes/utils.py
+++ b/src/anking_notetypes/utils.py
@@ -1,6 +1,7 @@
 import re
 import time
 from copy import deepcopy
+from typing import Dict, List
 
 from aqt import mw
 
@@ -33,7 +34,7 @@ def update_notetype_to_newest_version(
     if ankihub_field:
         new_model["flds"].append(ankihub_field)
 
-    new_model = adjust_field_ords(model, new_model)
+    new_model["flds"] = adjust_field_ords(model["flds"], new_model["flds"])
 
     new_model = _retain_ankihub_modifications(model, new_model)
 
@@ -109,28 +110,51 @@ def _updated_note_type_content(
 
 
 def adjust_field_ords(
-    cur_model: "NotetypeDict", new_model: "NotetypeDict"
-) -> "NotetypeDict":
-    # this makes sure that when fields get added or are moved
-    # field contents end up in the field with the same name as before
-    # note that the resulting model will have exactly the same set of fields as the new_model
-    for fld in new_model["flds"]:
-        if (
-            cur_ord := next(
-                (
-                    _fld["ord"]
-                    for _fld in cur_model["flds"]
-                    if _fld["name"] == fld["name"]
-                ),
-                None,
-            )
-        ) is not None:
-            fld["ord"] = cur_ord
+    cur_model_fields: List[Dict], new_model_fields: List[Dict]
+) -> List[Dict]:
+    """
+    Prepares note type fields for updates by merging fields from the current and new models.
+
+    This function handles several operations when updating note types:
+    1. Maintains field content mapping by assigning appropriate 'ord' values to matching fields
+    2. Assigns high 'ord' values to new fields so they start empty
+    3. Appends fields that only exist locally to the new model
+    4. Ensures the ankihub_id field remains at the end if it exists
+
+    Returns:
+        Updated note type fields
+    """
+    new_model_fields = deepcopy(new_model_fields)
+
+    cur_model_field_map = {
+        field["name"].lower(): field["ord"] for field in cur_model_fields
+    }
+
+    # Set appropriate ord values for each new field
+    for new_model_field in new_model_fields:
+        field_name_lower = new_model_field["name"].lower()
+        if field_name_lower in cur_model_field_map:
+            # If field exists in current model, preserve its ord value
+            new_model_field["ord"] = cur_model_field_map[field_name_lower]
         else:
-            # it's okay to assign this to multiple fields because the
-            # backend assigns new ords equal to the fields index
-            fld["ord"] = len(new_model["flds"]) - 1
-    return new_model
+            # For new fields, set ord to a value outside the range of current fields
+            new_model_field["ord"] = len(cur_model_fields) + 1
+
+    # Append fields that only exist locally to the new model, while keeping the ankihub_id field at the end
+    new_model_field_names = {field["name"].lower() for field in new_model_fields}
+    only_local_fields = [
+        field
+        for field in cur_model_fields
+        if field["name"].lower() not in new_model_field_names
+    ]
+    if new_model_fields[-1]["name"] == "ankihub_id":
+        final_fields = (
+            new_model_fields[:-1] + only_local_fields + [new_model_fields[-1]]
+        )
+    else:
+        final_fields = new_model_fields + only_local_fields
+
+    return final_fields
 
 
 def create_backup() -> None:

--- a/src/anking_notetypes/utils.py
+++ b/src/anking_notetypes/utils.py
@@ -34,7 +34,7 @@ def update_notetype_to_newest_version(
     if ankihub_field:
         new_model["flds"].append(ankihub_field)
 
-    new_model["flds"] = adjust_field_ords(model["flds"], new_model["flds"])
+    new_model["flds"] = adjust_fields(model["flds"], new_model["flds"])
 
     new_model = _retain_ankihub_modifications(model, new_model)
 
@@ -109,7 +109,7 @@ def _updated_note_type_content(
     )
 
 
-def adjust_field_ords(
+def adjust_fields(
     cur_model_fields: List[Dict], new_model_fields: List[Dict]
 ) -> List[Dict]:
     """

--- a/tests/expected.json
+++ b/tests/expected.json
@@ -672,7 +672,7 @@
         "autoreveal_personal_notes": false,
         "autoscroll_to_button": true,
         "back_signal_tag": "XXXYYYZZZ",
-        "back_tts": true,
+        "back_tts": false,
         "back_tts_speed": 1.4,
         "background_color": "#f8f9fd",
         "bold_text_color": "inherit",


### PR DESCRIPTION
Both, the AnkiHub add-on and the AnKing note types add-on, can update the fields of note types. We need to prevent issues where one add-on adds a field, and the other removes it, leading to loss of note fields contents for that field.

We can do this by changing the add-ons so that they only add fields, but don’t remove them. 
The add-ons should just add missing fields and ignore extra fields.
This will also have the effect that users will be able to add extra fields to the note type, without the fields getting reset during sync.

AnkiHub add-on PR: https://github.com/AnkiHubSoftware/ankihub_addon/pull/1117

## Related issues
https://ankihub.atlassian.net/jira/software/c/projects/NRT/boards/41?selectedIssue=NRT-34

### Resetting note type with extra fields
- Add a field to an AnKing note type (in Anki)
- Reset the note type using AnKing -> AnKing Note Types -> Go to the tab of the note type -> Reset -> Confirm
- Check that the field was not removed

You can also try removing a field which is on the note type (not only locally) and see that it gets added.
Additionally, you can position an extra local field after the ankihub_id field of an AnkiHub version of an AnKing note type, then reset. The new local extra field should be moved before the ankihub_id field.